### PR TITLE
Fixed bug: externalReference ignored

### DIFF
--- a/europeana-etranslation-research-core/pom.xml
+++ b/europeana-etranslation-research-core/pom.xml
@@ -16,6 +16,13 @@
  	
  	<properties>
     	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<translations.folder>/home/mmarrero/etranslation/translations-repository</translations.folder>
+		<log.file>/home/mmarrero/etranslation/callback-log.txt</log.file>
+		<etranslation.credentials>/home/mmarrero/.credentials/etranslation</etranslation.credentials>
+		<etranslation.username>Europeana_IR_20190225</etranslation.username>
+		<etranslation.url>https://webgate.ec.europa.eu/etranslation/si/translate</etranslation.url>
+		<etranslation.europeana.callback.url>http://rnd.eanadev.org/etranslation-callback/callback</etranslation.europeana.callback.url>
+		<etranslation.europeana.error.url>http://rnd.eanadev.org/etranslation-callback/error</etranslation.europeana.error.url>
     </properties>
     
 	<build>
@@ -101,5 +108,6 @@
 			<version>2.11.0</version>
 		</dependency>
 	</dependencies>	
+
 	
 </project>

--- a/europeana-etranslation-research-core/src/main/java/eu/europeana/research/etranslation/EtranslationApiRequest.java
+++ b/europeana-etranslation-research-core/src/main/java/eu/europeana/research/etranslation/EtranslationApiRequest.java
@@ -1,9 +1,7 @@
 package eu.europeana.research.etranslation;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
@@ -27,6 +25,9 @@ public class EtranslationApiRequest extends TranslationRequest {
 
 	public EtranslationApiRequest(EtranslationClient etranslationClient, String application, TranslationRequest req) {
 		this(etranslationClient, application, req.getText(), req.getSourceLanguage(), req.getTargetLanguages());
+		if (req instanceof EtranslationApiRequest) {
+			this.setExternalReference(((EtranslationApiRequest) req).getExternalReference());
+		}
 	}
 	
 	public JSONObject getJson() {
@@ -63,6 +64,10 @@ public class EtranslationApiRequest extends TranslationRequest {
 		return getJson().toString();
 	}
 
+	public String getExternalReference() {
+		return externalReference;
+	}
+	
 	public void setExternalReference(String externalReference) {
 		this.externalReference = externalReference;
 	}

--- a/europeana-etranslation-research-core/src/main/java/eu/europeana/research/etranslation/EtranslationApiRequest.java
+++ b/europeana-etranslation-research-core/src/main/java/eu/europeana/research/etranslation/EtranslationApiRequest.java
@@ -25,9 +25,11 @@ public class EtranslationApiRequest extends TranslationRequest {
 
 	public EtranslationApiRequest(EtranslationClient etranslationClient, String application, TranslationRequest req) {
 		this(etranslationClient, application, req.getText(), req.getSourceLanguage(), req.getTargetLanguages());
-		if (req instanceof EtranslationApiRequest) {
-			this.setExternalReference(((EtranslationApiRequest) req).getExternalReference());
-		}
+	}
+	
+	public EtranslationApiRequest(EtranslationClient etranslationClient, String application, EtranslationApiRequest req) {
+		this(etranslationClient, application, req.getText(), req.getSourceLanguage(), req.getTargetLanguages());
+		this.setExternalReference(req.getExternalReference());
 	}
 	
 	public JSONObject getJson() {

--- a/europeana-etranslation-research-core/src/main/java/eu/europeana/research/etranslation/EtranslationClient.java
+++ b/europeana-etranslation-research-core/src/main/java/eu/europeana/research/etranslation/EtranslationClient.java
@@ -36,6 +36,11 @@ public class EtranslationClient {
 	}
 	
 	public String sendRequest(TranslationRequest req) throws InterruptedException, IOException, AccessException {
+		EtranslationApiRequest eTransReq=new EtranslationApiRequest(this, userName, req);
+		return sendRequest(eTransReq);
+	}
+	
+	public String sendRequest(EtranslationApiRequest req) throws InterruptedException, IOException, AccessException {
 		try {
 			EtranslationApiRequest eTransReq=new EtranslationApiRequest(this, userName, req);
 			UrlRequest urlRequestSettings = new UrlRequest(url, HttpMethod.POST);

--- a/europeana-etranslation-research-core/src/main/java/eu/europeana/research/etranslation/test/TestExampleFromEtranslation.java
+++ b/europeana-etranslation-research-core/src/main/java/eu/europeana/research/etranslation/test/TestExampleFromEtranslation.java
@@ -33,9 +33,8 @@ public class TestExampleFromEtranslation {
 			try {
 				String userName = "Europeana_IR_20190225";
 	//	String userName = "nuno.freire@europeana.eu";
-				File credentials = new File("C:\\Users\\nfrei\\.credentials\\etranslation");
+				File credentials = new File("/home/mmarrero/.credentials/etranslation");
 				String password = FileUtils.readFileToString(credentials, "UTF-8");
-	
 				String url = "https://webgate.ec.europa.eu/etranslation/si/translate";
 				DefaultHttpClient client = new DefaultHttpClient();
 				client.getCredentialsProvider().setCredentials(AuthScope.ANY,


### PR DESCRIPTION
When sending the request, attributes not included in TranslationRequest are ignored (e.g. externalReference)